### PR TITLE
Fix code scanning alert #43: Multiplication result converted to larger type

### DIFF
--- a/drivers/firmware/efi/memattr.c
+++ b/drivers/firmware/efi/memattr.c
@@ -39,7 +39,7 @@ int __init efi_memattr_init(void)
 		goto unmap;
 	}
 
-	tbl_size = sizeof(*tbl) + tbl->num_entries * tbl->desc_size;
+	tbl_size = sizeof(*tbl) + (unsigned long)tbl->num_entries * tbl->desc_size;
 	memblock_reserve(efi_mem_attr_table, tbl_size);
 	set_bit(EFI_MEM_ATTR, &efi.flags);
 


### PR DESCRIPTION
Fixes [https://github.com/offsoc/linux/security/code-scanning/43](https://github.com/offsoc/linux/security/code-scanning/43)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
