### PR TITLE
Fix code scanning alert #1: Binding a socket to all network interfaces

### DIFF
--- a/tools/testing/selftests/net/lib/py/utils.py
+++ b/tools/testing/selftests/net/lib/py/utils.py
@@ -129,7 +129,7 @@ def rand_port():
         port = random.randint(10000, 65535)
         try:
             with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
-                s.bind(("", port))
+                s.bind(("::1", port))
             return port
         except OSError as e:
             if e.errno != errno.EADDRINUSE:


### PR DESCRIPTION
Fixes [https://github.com/offsoc/linux/security/code-scanning/1](https://github.com/offsoc/linux/security/code-scanning/1)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
