### PR TITLE
Potential fix for code scanning alert no. 49: Likely overrunning write

### DIFF
--- a/arch/x86/kernel/hpet.c
+++ b/arch/x86/kernel/hpet.c
@@ -722,7 +722,7 @@ static void __init hpet_select_clockevents(void)
 		if (!(hc->boot_cfg & HPET_TN_FSB_CAP))
 			continue;
 
-		sprintf(hc->name, "hpet%d", i);
+		snprintf(hc->name, sizeof(hc->name), "hpet%d", i);
 
 		irq = hpet_assign_irq(hpet_domain, hc, hc->num);
 		if (irq <= 0)


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/49](https://github.com/offsoc/linux/security/code-scanning/49)

To fix the issue, replace `sprintf` with `snprintf`, specifying the size of the `name` buffer (`sizeof(hc->name`) as the maximum length to write. This ensures that the formatted string will not exceed the buffer's capacity, preventing buffer overflow. 

The required change is in the call to `sprintf` on line 725. The format string and arguments remain unchanged, but the buffer size is explicitly controlled with `snprintf`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
