### PR TITLE
Potential fix for code scanning alert no. 38: Multiplication result converted to larger type

### DIFF
--- a/drivers/virtio/virtio_pci_modern_dev.c
+++ b/drivers/virtio/virtio_pci_modern_dev.c
@@ -712,8 +712,8 @@ void __iomem *vp_modern_map_vq_notify(struct virtio_pci_modern_device *mdev,
 		}
 		if (pa)
 			*pa = mdev->notify_pa +
-			      off * mdev->notify_offset_multiplier;
-		return mdev->notify_base + off * mdev->notify_offset_multiplier;
+			      (u64)off * mdev->notify_offset_multiplier;
+		return mdev->notify_base + (u64)off * mdev->notify_offset_multiplier;
 	} else {
 		return vp_modern_map_capability(mdev,
 				       mdev->notify_map_cap, 2, 2,


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/38](https://github.com/offsoc/linux/security/code-scanning/38)

To fix the problem, the multiplication should be performed in the larger type (`u64` or `resource_size_t`) so that the result cannot overflow a 32-bit integer before being assigned to the 64-bit variable. This can be achieved by casting one of the operands to `u64` before the multiplication. Specifically, in the assignment to `*pa` and in the pointer arithmetic for `mdev->notify_base`, change `off * mdev->notify_offset_multiplier` to `(u64)off * mdev->notify_offset_multiplier`. This ensures the multiplication is performed as a 64-bit operation. Only lines 715 and 716 need to be changed in the file `drivers/virtio/virtio_pci_modern_dev.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
