### PR TITLE
Potential fix for code scanning alert no. 6: Multiplication result converted to larger type

### DIFF
--- a/lib/objpool.c
+++ b/lib/objpool.c
@@ -66,7 +66,7 @@ objpool_init_percpu_slots(struct objpool_head *pool, int nr_objs,
 		cpu_count++;
 
 		size = struct_size(slot, entries, pool->capacity) +
-			pool->obj_size * nodes;
+			(size_t)pool->obj_size * nodes;
 
 		/*
 		 * here we allocate percpu-slot & objs together in a single


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/6](https://github.com/offsoc/linux/security/code-scanning/6)

To fix the problem, the multiplication should be performed in the larger type (`size_t` or `unsigned long`) rather than in `int`. This can be achieved by casting one of the operands to `size_t` before the multiplication, ensuring that the result is computed in the larger type and overflow is avoided. The best way to fix this is to change line 69 in `lib/objpool.c` so that the multiplication is performed as `(size_t)pool->obj_size * nodes` or `pool->obj_size * (size_t)nodes`. No new imports or definitions are needed, as casting is a standard C operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
