### PR TITLE
Potential fix for code scanning alert no. 7: Multiplication result converted to larger type

### DIFF
--- a/lib/percpu_counter.c
+++ b/lib/percpu_counter.c
@@ -336,7 +336,7 @@ bool __percpu_counter_limited_add(struct percpu_counter *fbc,
 		return true;
 
 	local_irq_save(flags);
-	unknown = batch * num_online_cpus();
+	unknown = (s64)batch * num_online_cpus();
 	count = __this_cpu_read(*fbc->counters);
 
 	/* Skip taking the lock when safe */


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/7](https://github.com/offsoc/linux/security/code-scanning/7)

To fix the problem, we should ensure that the multiplication between `batch` and `num_online_cpus()` is performed in `s64` arithmetic, not in `int` or `unsigned int`. This can be done by explicitly casting one of the operands to `s64` before the multiplication. The best way is to cast `batch` to `s64`, since it is already signed, and this will ensure the multiplication is performed in the correct type. The change should be made on line 339 in the function `__percpu_counter_limited_add` in `lib/percpu_counter.c`. No new imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
