### PR TITLE
Potential fix for code scanning alert no. 18: Multiplication result converted to larger type

### DIFF
--- a/drivers/base/regmap/regcache-rbtree.c
+++ b/drivers/base/regmap/regcache-rbtree.c
@@ -298,7 +298,7 @@ static int regcache_rbtree_insert_to_block(struct regmap *map,
 	/* insert the register value in the correct place in the rbnode block */
 	if (pos == 0) {
 		memmove(blk + offset * map->cache_word_size,
-			blk, rbnode->blklen * map->cache_word_size);
+			blk, (size_t)rbnode->blklen * map->cache_word_size);
 		bitmap_shift_left(present, present, offset, blklen);
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/18](https://github.com/offsoc/linux/security/code-scanning/18)

To fix this problem, we should ensure that the multiplication is performed in the larger type (`size_t`) to avoid overflow. This can be done by casting one of the operands to `size_t` before the multiplication. The best way to do this is to cast either `rbnode->blklen` or `map->cache_word_size` to `size_t` in the call to `memmove` on line 301. This change is local, does not affect existing functionality, and is safe. No new imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
