### PR TITLE
Potential fix for code scanning alert no. 55: Multiplication result converted to larger type

### DIFF
--- a/drivers/gpu/drm/display/drm_dsc_helper.c
+++ b/drivers/gpu/drm/display/drm_dsc_helper.c
@@ -1352,7 +1352,7 @@ int drm_dsc_compute_rc_parameters(struct drm_dsc_config *vdsc_cfg)
 			(4 * vdsc_cfg->bits_per_component + 4) +
 			2 * (4 * vdsc_cfg->bits_per_component) - 2;
 	/* Number of bits in one Slice */
-	slice_bits = 8 * vdsc_cfg->slice_chunk_size * vdsc_cfg->slice_height;
+	slice_bits = 8UL * vdsc_cfg->slice_chunk_size * vdsc_cfg->slice_height;
 
 	while ((num_extra_mux_bits > 0) &&
 	       ((slice_bits - num_extra_mux_bits) % vdsc_cfg->mux_word_size))


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/55](https://github.com/offsoc/linux/security/code-scanning/55)

To fix the problem, we should ensure that the multiplication is performed using a type large enough to hold the result before any conversion occurs. This can be done by casting one of the operands to `unsigned long` (or `long`, depending on the expected type of `slice_bits`) before the multiplication. The best way is to cast the first operand, so the entire multiplication is done in the larger type. Specifically, change line 1355 from:

```c
slice_bits = 8 * vdsc_cfg->slice_chunk_size * vdsc_cfg->slice_height;
```

to:

```c
slice_bits = 8UL * vdsc_cfg->slice_chunk_size * vdsc_cfg->slice_height;
```

or, if `slice_bits` is of type `unsigned long`, cast one of the operands:

```c
slice_bits = (unsigned long)8 * vdsc_cfg->slice_chunk_size * vdsc_cfg->slice_height;
```

Alternatively, cast one of the variables:

```c
slice_bits = (unsigned long)vdsc_cfg->slice_chunk_size * 8 * vdsc_cfg->slice_height;
```

The simplest and most idiomatic fix in C is to use the `UL` suffix for the constant, which ensures the multiplication is performed in `unsigned long` arithmetic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
