### PR TITLE
Potential fix for code scanning alert no. 25: Multiplication result converted to larger type

### DIFF
--- a/drivers/gpu/drm/drm_gem_shmem_helper.c
+++ b/drivers/gpu/drm/drm_gem_shmem_helper.c
@@ -518,13 +518,13 @@ int drm_gem_shmem_dumb_create(struct drm_file *file, struct drm_device *dev,
 
 	if (!args->pitch || !args->size) {
 		args->pitch = min_pitch;
-		args->size = PAGE_ALIGN(args->pitch * args->height);
+		args->size = PAGE_ALIGN((u64)args->pitch * args->height);
 	} else {
 		/* ensure sane minimum values */
 		if (args->pitch < min_pitch)
 			args->pitch = min_pitch;
 		if (args->size < args->pitch * args->height)
-			args->size = PAGE_ALIGN(args->pitch * args->height);
+			args->size = PAGE_ALIGN((u64)args->pitch * args->height);
 	}
 
 	return drm_gem_shmem_create_with_handle(file, dev, args->size, &args->handle);


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/25](https://github.com/offsoc/linux/security/code-scanning/25)

To fix the problem, the multiplication should be performed in a type large enough to hold the result before any overflow can occur. This means casting one of the operands to `u64` (or `unsigned long long`) before multiplying, ensuring the multiplication is done in the larger type. Specifically, in the expressions `args->pitch * args->height` on lines 521 and 526, cast `args->pitch` (or `args->height`) to `u64` before multiplying. This change should be made in both places where the multiplication occurs, to ensure correctness regardless of which branch is taken.

No new imports or definitions are needed, as `u64` is already available in the kernel.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
