### PR TITLE
Potential fix for code scanning alert no. 21: Multiplication result converted to larger type

### DIFF
--- a/drivers/firmware/efi/earlycon.c
+++ b/drivers/firmware/efi/earlycon.c
@@ -107,7 +107,7 @@ static void efi_earlycon_scroll_up(void)
 		if (!dst)
 			return;
 
-		src = efi_earlycon_map((i + font->height) * len, len);
+		src = efi_earlycon_map((unsigned long)(i + font->height) * len, len);
 		if (!src) {
 			efi_earlycon_unmap(dst, len);
 			return;


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/21](https://github.com/offsoc/linux/security/code-scanning/21)

To fix the problem, we need to ensure that the multiplication is performed using the larger type (`unsigned long`) so that no overflow can occur before the result is passed to `efi_earlycon_map`. This can be done by explicitly casting one of the operands to `unsigned long` before the multiplication. The best place to do this is in the call to `efi_earlycon_map` on line 110, changing:

```c
src = efi_earlycon_map((i + font->height) * len, len);
```

to

```c
src = efi_earlycon_map((unsigned long)(i + font->height) * len, len);
```

This ensures that the addition and multiplication are performed in `unsigned long` arithmetic, preventing overflow.

No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
