### PR TITLE
Potential fix for code scanning alert no. 40: Multiplication result converted to larger type

### DIFF
--- a/fs/ext4/readpage.c
+++ b/fs/ext4/readpage.c
@@ -253,7 +253,7 @@ int ext4_mpage_readpages(struct inode *inode,
 		first_hole = blocks_per_folio;
 		block_in_file = next_block =
 			(sector_t)folio->index << (PAGE_SHIFT - blkbits);
-		last_block = block_in_file + nr_pages * blocks_per_page;
+		last_block = block_in_file + (sector_t)nr_pages * blocks_per_page;
 		last_block_in_file = (ext4_readpage_limit(inode) +
 				      blocksize - 1) >> blkbits;
 		if (last_block > last_block_in_file)


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/40](https://github.com/offsoc/linux/security/code-scanning/40)

To fix the problem, we need to ensure that the multiplication is performed in the larger type (`sector_t`) rather than in `unsigned int`. This can be done by casting one of the operands to `sector_t` before the multiplication, so that the result is computed in the wider type and overflow is avoided. Specifically, in the assignment to `last_block` on line 256, change `nr_pages * blocks_per_page` to `(sector_t)nr_pages * blocks_per_page`. Only this line needs to be changed, and no additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
