### PR TITLE
Potential fix for code scanning alert no. 35: Multiplication result converted to larger type

### DIFF
--- a/drivers/tty/vt/vt.c
+++ b/drivers/tty/vt/vt.c
@@ -587,8 +587,8 @@ static void con_scroll(struct vc_data *vc, unsigned int top,
 			vc->vc_sw->con_scroll(vc, top, bottom, dir, nr))
 		return;
 
-	src = clear = (u16 *)(vc->vc_origin + vc->vc_size_row * top);
-	dst = (u16 *)(vc->vc_origin + vc->vc_size_row * (top + nr));
+	src = clear = (u16 *)(vc->vc_origin + (unsigned long)vc->vc_size_row * top);
+	dst = (u16 *)(vc->vc_origin + (unsigned long)vc->vc_size_row * (top + nr));
 
 	if (dir == SM_UP) {
 		clear = src + (rows - nr) * vc->vc_cols;


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/35](https://github.com/offsoc/linux/security/code-scanning/35)

To fix the problem, we should ensure that the multiplication is performed in `unsigned long` arithmetic, not `unsigned int`. This can be done by casting one of the operands to `unsigned long` before the multiplication. Specifically, in the expressions `(vc->vc_origin + vc->vc_size_row * top)` and `(vc->vc_origin + vc->vc_size_row * (top + nr))`, we should cast `vc->vc_size_row` or `top` to `unsigned long` before multiplying. This change should be made in both places on lines 590 and 591. No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
