### PR TITLE
Potential fix for code scanning alert no. 59: Multiplication result converted to larger type

### DIFF
--- a/drivers/firmware/efi/earlycon.c
+++ b/drivers/firmware/efi/earlycon.c
@@ -103,7 +103,7 @@ static void efi_earlycon_scroll_up(void)
 	height = screen_info.lfb_height;
 
 	for (i = 0; i < height - font->height; i++) {
-		dst = efi_earlycon_map(i*len, len);
+		dst = efi_earlycon_map((unsigned long)i * len, len);
 		if (!dst)
 			return;
 


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/59](https://github.com/offsoc/linux/security/code-scanning/59)

To fix the problem, ensure that the multiplication is performed in the larger type (`unsigned long`) so that overflow does not occur in the smaller type. This can be done by casting one of the operands to `unsigned long` before the multiplication. Specifically, in the call to `efi_earlycon_map(i*len, len);` on line 106, cast `i` to `unsigned long` so that the multiplication is performed in the larger type. Only this line needs to be changed in the file `drivers/firmware/efi/earlycon.c`. No new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
