### PR TITLE
Potential fix for code scanning alert no. 45: Multiplication result converted to larger type

### DIFF
--- a/fs/quota/quota_tree.c
+++ b/fs/quota/quota_tree.c
@@ -323,7 +323,7 @@ static uint find_free_dqentry(struct qtree_mem_dqinfo *info,
 	}
 	dquot->dq_off = ((loff_t)blk << info->dqi_blocksize_bits) +
 			sizeof(struct qt_disk_dqdbheader) +
-			i * info->dqi_entry_size;
+			(loff_t)i * info->dqi_entry_size;
 	kfree(buf);
 	return blk;
 out_buf:


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/45](https://github.com/offsoc/linux/security/code-scanning/45)

To fix the problem, we need to ensure that the multiplication is performed in the larger type (`loff_t`) rather than in `int` or `unsigned int`. This is done by casting one of the operands to `loff_t` before the multiplication, so that the multiplication is performed in 64 bits and cannot overflow as long as the result fits in a `loff_t`. The best way to do this is to cast `i` or `info->dqi_entry_size` to `loff_t` in the expression on line 326. No additional imports or definitions are needed, as `loff_t` is already in use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
