### PR TITLE
Potential fix for code scanning alert no. 8: Multiplication result converted to larger type

### DIFF
--- a/mm/numa_memblks.c
+++ b/mm/numa_memblks.c
@@ -59,7 +59,7 @@ static int __init numa_alloc_distance(void)
 	for_each_node_mask(i, nodes_parsed)
 		cnt = i;
 	cnt++;
-	size = cnt * cnt * sizeof(numa_distance[0]);
+	size = (size_t)cnt * cnt * sizeof(numa_distance[0]);
 
 	numa_distance = memblock_alloc(size, PAGE_SIZE);
 	if (!numa_distance) {


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/8](https://github.com/offsoc/linux/security/code-scanning/8)

To fix the problem, we should ensure that the multiplication is performed using the larger type (`size_t`) rather than `int`. This can be done by casting one of the operands to `size_t` before the multiplication, so that the multiplication is performed in `size_t` arithmetic, preventing overflow. Specifically, in `size = cnt * cnt * sizeof(numa_distance[0]);`, we should cast `cnt` to `size_t` in at least one of the multiplications, e.g., `size = (size_t)cnt * cnt * sizeof(numa_distance[0]);`. Only line 62 in `mm/numa_memblks.c` needs to be changed; no new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
