### PR TITLE
Potential fix for code scanning alert no. 10: Multiplication result converted to larger type

### DIFF
--- a/sound/core/seq/seq_timer.c
+++ b/sound/core/seq/seq_timer.c
@@ -30,7 +30,7 @@ static void snd_seq_timer_set_tick_resolution(struct snd_seq_timer *tmr)
 		unsigned int s;
 		s = tmr->tempo % tmr->ppq;
 		s = (s * tmr->tempo_base) / tmr->ppq;
-		tmr->tick.resolution = (tmr->tempo / tmr->ppq) * tmr->tempo_base;
+		tmr->tick.resolution = (unsigned long)(tmr->tempo / tmr->ppq) * tmr->tempo_base;
 		tmr->tick.resolution += s;
 	}
 	if (tmr->tick.resolution <= 0)


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/10](https://github.com/offsoc/linux/security/code-scanning/10)

To fix the problem, the multiplication should be performed using the larger integer type so that overflow does not occur. This can be achieved by casting one of the operands to the larger type (`unsigned long`) before the multiplication. Specifically, in line 33, cast `(tmr->tempo / tmr->ppq)` to `unsigned long` before multiplying by `tmr->tempo_base`. This ensures that the multiplication is performed in the larger type, preventing overflow. Only line 33 in `sound/core/seq/seq_timer.c` needs to be changed. No new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
