### PR TITLE
Potential fix for code scanning alert no. 11: Multiplication result converted to larger type

### DIFF
--- a/arch/x86/boot/compressed/misc.c
+++ b/arch/x86/boot/compressed/misc.c
@@ -96,7 +96,7 @@ static void scroll(void)
 {
 	int i;
 
-	memmove(vidmem, vidmem + cols * 2, (lines - 1) * cols * 2);
+	memmove(vidmem, vidmem + cols * 2, (size_t)(lines - 1) * cols * 2);
 	for (i = (lines - 1) * cols * 2; i < lines * cols * 2; i += 2)
 		vidmem[i] = ' ';
 }


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/11](https://github.com/offsoc/linux/security/code-scanning/11)

To fix the problem, ensure that the multiplication is performed using the larger type (`size_t`) rather than `int`. This can be done by explicitly casting one of the operands to `size_t` before performing the multiplication. This way, the entire multiplication will be done in `size_t` arithmetic, preventing overflow that could occur if the multiplication were done in `int` and only then promoted. The best place to do this is in the call to `memmove` on line 99, by casting the first operand (`lines - 1`) to `size_t`. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
