### PR TITLE
Potential fix for code scanning alert no. 16: Multiplication result converted to larger type

### DIFF
--- a/arch/x86/kernel/tsc_msr.c
+++ b/arch/x86/kernel/tsc_msr.c
@@ -204,7 +204,7 @@ unsigned long cpu_khz_from_msr(void)
 		res = DIV_ROUND_CLOSEST(tscref * ratio, md->divider);
 	} else {
 		freq = freq_desc->freqs[index];
-		res = freq * ratio;
+		res = (unsigned long)freq * ratio;
 	}
 
 	if (freq == 0)


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/16](https://github.com/offsoc/linux/security/code-scanning/16)

To fix the problem, ensure that the multiplication is performed in the larger type (`unsigned long`) so that overflow does not occur. This is done by casting one of the operands to `unsigned long` before the multiplication. Specifically, in the line `res = freq * ratio;`, cast either `freq` or `ratio` to `unsigned long` so that the multiplication is performed in 64 bits. Only line 207 in `arch/x86/kernel/tsc_msr.c` needs to be changed. No new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
