### PR TITLE
Potential fix for code scanning alert no. 27: Multiplication result converted to larger type

### DIFF
--- a/drivers/gpu/drm/virtio/virtgpu_gem.c
+++ b/drivers/gpu/drm/virtio/virtgpu_gem.c
@@ -72,7 +72,7 @@ int virtio_gpu_mode_dumb_create(struct drm_file *file_priv,
 		return -EINVAL;
 
 	pitch = args->width * 4;
-	args->size = pitch * args->height;
+	args->size = (__u64)pitch * args->height;
 	args->size = ALIGN(args->size, PAGE_SIZE);
 
 	params.format = virtio_gpu_translate_format(DRM_FORMAT_HOST_XRGB8888);


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/27](https://github.com/offsoc/linux/security/code-scanning/27)

To fix the problem, we need to ensure that the multiplication is performed in 64 bits, so that any result that fits in a 64-bit integer is computed correctly, and no overflow occurs in the intermediate result. The best way to do this is to cast one of the operands to `__u64` before the multiplication. This will promote the other operand as well, and the multiplication will be performed in 64 bits. Specifically, in the line `args->size = pitch * args->height;`, we should change it to `args->size = (__u64)pitch * args->height;`. This change should be made in the file `drivers/gpu/drm/virtio/virtgpu_gem.c`, at the line where `args->size` is assigned.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
