### PR TITLE
Potential fix for code scanning alert no. 39: Multiplication result converted to larger type

### DIFF
--- a/include/linux/backing-dev.h
+++ b/include/linux/backing-dev.h
@@ -94,7 +94,7 @@ extern void wb_writeout_inc(struct bdi_writeback *wb);
 static inline unsigned long wb_stat_error(void)
 {
 #ifdef CONFIG_SMP
-	return nr_cpu_ids * WB_STAT_BATCH;
+	return (unsigned long)nr_cpu_ids * WB_STAT_BATCH;
 #else
 	return 1;
 #endif


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/39](https://github.com/offsoc/linux/security/code-scanning/39)

To fix the problem, ensure that the multiplication is performed in the larger type (`unsigned long`) by casting one of the operands to `unsigned long` before the multiplication. This can be done by casting either `nr_cpu_ids` or `WB_STAT_BATCH` to `unsigned long` in the return statement. The change should be made in the function `wb_stat_error()` in `include/linux/backing-dev.h`, specifically in the `#ifdef CONFIG_SMP` branch. No new imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
