### PR TITLE
Potential fix for code scanning alert no. 60: Multiplication result converted to larger type

### DIFF
--- a/drivers/gpu/drm/drm_gem_shmem_helper.c
+++ b/drivers/gpu/drm/drm_gem_shmem_helper.c
@@ -527,7 +527,7 @@ int drm_gem_shmem_dumb_create(struct drm_file *file, struct drm_device *dev,
 		/* ensure sane minimum values */
 		if (args->pitch < min_pitch)
 			args->pitch = min_pitch;
-		if (args->size < args->pitch * args->height)
+		if (args->size < (u64)args->pitch * args->height)
 			args->size = PAGE_ALIGN((u64)args->pitch * args->height);
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/60](https://github.com/offsoc/linux/security/code-scanning/60)

To fix the problem, the multiplication should be performed in the larger type (`u64`) to avoid overflow. This is done by casting one of the operands to `u64` before the multiplication, ensuring the result is computed in 64 bits. Specifically, in the condition on line 530, change `args->size < args->pitch * args->height` to `args->size < (u64)args->pitch * args->height`. This matches the pattern already used in the assignment on line 531. No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
