### PR TITLE
Potential fix for code scanning alert no. 42: Multiplication result converted to larger type

### DIFF
--- a/fs/fat/fatent.c
+++ b/fs/fat/fatent.c
@@ -587,7 +587,7 @@ int fat_free_clusters(struct inode *inode, int cluster)
 
 				sb_issue_discard(sb,
 					fat_clus_to_blknr(sbi, first_cl),
-					nr_clus * sbi->sec_per_clus,
+					((sector_t)nr_clus) * sbi->sec_per_clus,
 					GFP_NOFS, 0);
 
 				first_cl = cluster;


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/42](https://github.com/offsoc/linux/security/code-scanning/42)

To fix the problem, we should ensure that the multiplication is performed in the larger type (`sector_t`) to avoid overflow. This is done by casting one of the operands to `sector_t` before the multiplication, so the multiplication is performed in 64 bits. The best way to do this is to cast `nr_clus` to `sector_t` in the call to `sb_issue_discard` on line 590. No additional imports or definitions are needed, as `sector_t` is already in use.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
