### PR TITLE
Potential fix for code scanning alert no. 13: Multiplication result converted to larger type

### DIFF
--- a/arch/x86/events/intel/uncore.h
+++ b/arch/x86/events/intel/uncore.h
@@ -311,7 +311,7 @@ static inline unsigned uncore_msr_box_offset(struct intel_uncore_box *box)
 	struct intel_uncore_pmu *pmu = box->pmu;
 	return pmu->type->msr_offsets ?
 		pmu->type->msr_offsets[pmu->pmu_idx] :
-		pmu->type->msr_offset * pmu->pmu_idx;
+		((unsigned long)pmu->type->msr_offset) * pmu->pmu_idx;
 }
 
 static inline unsigned uncore_msr_box_ctl(struct intel_uncore_box *box)


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/13](https://github.com/offsoc/linux/security/code-scanning/13)

To fix the problem, we should ensure that the multiplication between `pmu->type->msr_offset` and `pmu->pmu_idx` is performed in a larger type (such as `unsigned long` or `unsigned long long`) to avoid overflow. This can be done by explicitly casting one of the operands to the larger type before the multiplication. Since the function returns `unsigned`, but the multiplication may be used in a context expecting a larger type, it is best to perform the multiplication in the larger type and, if necessary, cast the result back to `unsigned` for the return value. The change should be made on line 314 in the file `arch/x86/events/intel/uncore.h`, specifically in the `uncore_msr_box_offset` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
