### PR TITLE
Potential fix for code scanning alert no. 14: Multiplication result converted to larger type

### DIFF
--- a/arch/x86/events/intel/uncore_discovery.c
+++ b/arch/x86/events/intel/uncore_discovery.c
@@ -298,7 +298,7 @@ static int __parse_discovery_table(resource_size_t addr, int die,
 	}
 	iounmap(io_addr);
 
-	size = (1 + global.max_units) * global.stride * 8;
+	size = (unsigned long)(1 + global.max_units) * global.stride * 8;
 	io_addr = ioremap(addr, size);
 	if (!io_addr)
 		return -ENOMEM;


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/14](https://github.com/offsoc/linux/security/code-scanning/14)

To fix the problem, we need to ensure that the multiplication is performed using the larger type (`unsigned long`) so that no intermediate overflow can occur. This is done by casting one of the operands to `unsigned long` before the multiplication. The best way is to cast the first operand, `(1 + global.max_units)`, to `unsigned long`, so that the entire multiplication is performed in the larger type. Only the code on line 301 in `arch/x86/events/intel/uncore_discovery.c` needs to be changed. No new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
