### PR TITLE
Potential fix for code scanning alert no. 29: Multiplication result converted to larger type

### DIFF
--- a/drivers/scsi/scsi_lib.c
+++ b/drivers/scsi/scsi_lib.c
@@ -763,7 +763,7 @@ static bool scsi_cmd_runtime_exceeced(struct scsi_cmnd *cmd)
 	if (cmd->allowed == SCSI_CMD_RETRIES_NO_LIMIT)
 		return false;
 
-	wait_for = (cmd->allowed + 1) * req->timeout;
+	wait_for = (unsigned long)(cmd->allowed + 1) * req->timeout;
 	if (time_before(cmd->jiffies_at_alloc + wait_for, jiffies)) {
 		scmd_printk(KERN_ERR, cmd, "timing out command, waited %lus\n",
 			    wait_for/HZ);


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/29](https://github.com/offsoc/linux/security/code-scanning/29)

To fix this issue, ensure that the multiplication is performed in the larger type (`unsigned long`) by casting one of the operands to `unsigned long` before the multiplication. This can be done by casting either `cmd->allowed` or `req->timeout` (or both) to `unsigned long` in the expression. The best way is to cast the sum `(cmd->allowed + 1)` to `unsigned long`, so the multiplication is performed in the correct type. Only line 766 in `drivers/scsi/scsi_lib.c` needs to be changed. No new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
