### PR TITLE
Potential fix for code scanning alert no. 61: Multiplication result converted to larger type

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_dp.c
+++ b/drivers/gpu/drm/i915/display/intel_dp.c
@@ -721,7 +721,7 @@ static void intel_dp_link_config_init(struct intel_dp *intel_dp)
 
 	num_common_lane_configs = ilog2(intel_dp_max_common_lane_count(intel_dp)) + 1;
 
-	if (drm_WARN_ON(display->drm, intel_dp->num_common_rates * num_common_lane_configs >
+	if (drm_WARN_ON(display->drm, (unsigned long)intel_dp->num_common_rates * num_common_lane_configs >
 				    ARRAY_SIZE(intel_dp->link.configs)))
 		return;
 


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/61](https://github.com/offsoc/linux/security/code-scanning/61)

To fix the problem, ensure that the multiplication is performed in the larger type (`unsigned long`) so that no overflow can occur before the comparison. This is done by casting one of the operands to `unsigned long` before the multiplication. The best way to do this is to cast `intel_dp->num_common_rates` to `unsigned long` in the multiplication on line 724. No additional imports or definitions are needed, as casting is a standard C operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
