### PR TITLE
Potential fix for code scanning alert no. 41: Multiplication result converted to larger type

### DIFF
--- a/fs/fat/fatent.c
+++ b/fs/fat/fatent.c
@@ -756,7 +756,7 @@ static int fat_trim_clusters(struct super_block *sb, u32 clus, u32 nr_clus)
 {
 	struct msdos_sb_info *sbi = MSDOS_SB(sb);
 	return sb_issue_discard(sb, fat_clus_to_blknr(sbi, clus),
-				nr_clus * sbi->sec_per_clus, GFP_NOFS, 0);
+				((sector_t)nr_clus) * sbi->sec_per_clus, GFP_NOFS, 0);
 }
 
 int fat_trim_fs(struct inode *inode, struct fstrim_range *range)


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/41](https://github.com/offsoc/linux/security/code-scanning/41)

To fix this problem, we should ensure that the multiplication is performed in the larger type (`sector_t`) to avoid overflow. This can be done by casting one of the operands to `sector_t` before the multiplication, so that the multiplication is performed in 64 bits (or whatever size `sector_t` is). The best way to do this is to cast `nr_clus` to `sector_t` in the call to `sb_issue_discard` on line 759. No additional imports or definitions are needed, as `sector_t` is already in use in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
