### PR TITLE
Potential fix for code scanning alert no. 34: Multiplication result converted to larger type

### DIFF
--- a/drivers/tty/vt/vt.c
+++ b/drivers/tty/vt/vt.c
@@ -879,7 +879,7 @@ static void set_origin(struct vc_data *vc)
 		vc->vc_origin = (unsigned long)vc->vc_screenbuf;
 	vc->vc_visible_origin = vc->vc_origin;
 	vc->vc_scr_end = vc->vc_origin + vc->vc_screenbuf_size;
-	vc->vc_pos = vc->vc_origin + vc->vc_size_row * vc->state.y +
+	vc->vc_pos = vc->vc_origin + (unsigned long)vc->vc_size_row * vc->state.y +
 		2 * vc->state.x;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/34](https://github.com/offsoc/linux/security/code-scanning/34)

To fix the problem, we need to ensure that the multiplication is performed in the larger type (`unsigned long`) so that no overflow occurs. This is done by casting one of the operands to `unsigned long` before the multiplication. The best way to do this is to cast `vc->vc_size_row` to `unsigned long` in the expression on line 882. Only this line needs to be changed, and no new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
