### PR TITLE
Potential fix for code scanning alert no. 19: Multiplication result converted to larger type

### DIFF
--- a/drivers/firmware/efi/earlycon.c
+++ b/drivers/firmware/efi/earlycon.c
@@ -165,7 +165,7 @@ efi_earlycon_write(struct console *con, const char *str, unsigned int num)
 		for (h = 0; h < font->height; h++) {
 			unsigned int n, x;
 
-			dst = efi_earlycon_map((efi_y + h) * len, len);
+			dst = efi_earlycon_map((unsigned long)(efi_y + h) * len, len);
 			if (!dst)
 				return;
 


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/19](https://github.com/offsoc/linux/security/code-scanning/19)

To fix the problem, we should ensure that the multiplication is performed using a larger integer type, such as `unsigned long`, so that overflow does not occur. This can be done by casting one of the operands to `unsigned long` before the multiplication. Specifically, in the expression `(efi_y + h) * len` on line 168, we should cast either `(efi_y + h)` or `len` to `unsigned long` before multiplying. The best way is to cast `(efi_y + h)` to `unsigned long`, resulting in `(unsigned long)(efi_y + h) * len`. This change should be made in the file `drivers/firmware/efi/earlycon.c` at line 168.

No new imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
