### PR TITLE
Potential fix for code scanning alert no. 9: Multiplication result converted to larger type

### DIFF
--- a/mm/numa_memblks.c
+++ b/mm/numa_memblks.c
@@ -37,7 +37,7 @@ static void __init numa_nodemask_from_meminfo(nodemask_t *nodemask,
  */
 void __init numa_reset_distance(void)
 {
-	size_t size = numa_distance_cnt * numa_distance_cnt * sizeof(numa_distance[0]);
+	size_t size = (size_t)numa_distance_cnt * numa_distance_cnt * sizeof(numa_distance[0]);
 
 	/* numa_distance could be 1LU marking allocation failure, test cnt */
 	if (numa_distance_cnt)


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/9](https://github.com/offsoc/linux/security/code-scanning/9)

To fix the problem, the multiplication should be performed in the larger type (`size_t`) rather than in `int`. This can be achieved by casting one of the operands to `size_t` before the multiplication, ensuring that the entire operation is done in `size_t` arithmetic. Specifically, in `mm/numa_memblks.c`, line 40 should be changed from:

```c
size_t size = numa_distance_cnt * numa_distance_cnt * sizeof(numa_distance[0]);
```

to:

```c
size_t size = (size_t)numa_distance_cnt * numa_distance_cnt * sizeof(numa_distance[0]);
```

This ensures that the multiplication does not overflow the range of `int` before being converted to `size_t`. No new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
