### PR TITLE
Potential fix for code scanning alert no. 22: Multiplication result converted to larger type

### DIFF
--- a/drivers/firmware/efi/earlycon.c
+++ b/drivers/firmware/efi/earlycon.c
@@ -77,7 +77,7 @@ static void efi_earlycon_clear_scanline(unsigned int y)
 	u16 len;
 
 	len = screen_info.lfb_linelength;
-	dst = efi_earlycon_map(y*len, len);
+	dst = efi_earlycon_map((unsigned long)y * len, len);
 	if (!dst)
 		return;
 


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/22](https://github.com/offsoc/linux/security/code-scanning/22)

To fix the problem, ensure that the multiplication is performed using the larger type (`unsigned long`) so that overflow does not occur. This can be done by casting one of the operands to `unsigned long` before the multiplication. Specifically, in the call to `efi_earlycon_map(y*len, len);` on line 80, cast `y` to `unsigned long` so that the multiplication is performed as `unsigned long * u16`, resulting in an `unsigned long` value. Only line 80 in `drivers/firmware/efi/earlycon.c` needs to be changed. No new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
