### PR TITLE
Potential fix for code scanning alert no. 62: Multiplication result converted to larger type

### DIFF
--- a/drivers/tty/vt/vt.c
+++ b/drivers/tty/vt/vt.c
@@ -1229,7 +1229,7 @@ static int vc_do_resize(struct tty_struct *tty, struct vc_data *vc,
 			 */
 			first_copied_row = (vc->state.y - new_rows/2);
 		}
-		old_origin += first_copied_row * old_row_size;
+		old_origin += (unsigned long)first_copied_row * old_row_size;
 	} else
 		first_copied_row = 0;
 	end = old_origin + (unsigned long)old_row_size * min(old_rows, new_rows);


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/62](https://github.com/offsoc/linux/security/code-scanning/62)

To fix the problem, the multiplication should be performed in the larger type (`unsigned long`) to prevent overflow. This can be achieved by casting one of the operands to `unsigned long` before the multiplication, ensuring that the multiplication is done in the larger type. Specifically, in the line:

```c
old_origin += first_copied_row * old_row_size;
```

change it to:

```c
old_origin += (unsigned long)first_copied_row * old_row_size;
```

This ensures that the multiplication is performed as an `unsigned long` operation, preventing overflow that could occur if both operands are of a smaller type. No new imports or definitions are needed, as the cast uses standard C syntax.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
