### PR TITLE
Potential fix for code scanning alert no. 31: Multiplication result converted to larger type

### DIFF
--- a/drivers/tty/vt/vt.c
+++ b/drivers/tty/vt/vt.c
@@ -1419,7 +1419,7 @@ static void gotoxy(struct vc_data *vc, int new_x, int new_y)
 		vc->state.y = max_y - 1;
 	else
 		vc->state.y = new_y;
-	vc->vc_pos = vc->vc_origin + vc->state.y * vc->vc_size_row +
+	vc->vc_pos = vc->vc_origin + (unsigned long)vc->state.y * vc->vc_size_row +
 		(vc->state.x << 1);
 	vc->vc_need_wrap = 0;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/31](https://github.com/offsoc/linux/security/code-scanning/31)

To fix the problem, we should ensure that the multiplication is performed in the larger type (`unsigned long`) rather than in `unsigned int`. This can be done by explicitly casting one of the operands to `unsigned long` before the multiplication. The best way is to cast `vc->vc_size_row` (or `vc->state.y`) to `unsigned long` in the multiplication expression. This change should be made in the assignment to `vc->vc_pos` on line 1422 in `drivers/tty/vt/vt.c`. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
