### PR TITLE
Potential fix for code scanning alert no. 54: Binding a socket to all network interfaces

### DIFF
--- a/tools/testing/selftests/net/lib/py/utils.py
+++ b/tools/testing/selftests/net/lib/py/utils.py
@@ -229,7 +229,7 @@ def rand_port(type=socket.SOCK_STREAM):
     Get a random unprivileged port.
     """
     with socket.socket(socket.AF_INET6, type) as s:
-        s.bind(("", 0))
+        s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/54](https://github.com/offsoc/linux/security/code-scanning/54)

To fix the problem, change the socket binding in the `rand_port` function from `("", 0)` to `("127.0.0.1", 0)`. This ensures that the socket is only bound to the loopback interface, preventing any exposure on external network interfaces. The change should be made only in the `rand_port` function, specifically on line 232. No additional imports or method definitions are required, as `127.0.0.1` is a standard loopback address and the rest of the code remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
