### PR TITLE
Potential fix for code scanning alert no. 53: Binding a socket to all network interfaces

### DIFF
--- a/tools/testing/selftests/drivers/net/hw/rss_input_xfrm.py
+++ b/tools/testing/selftests/drivers/net/hw/rss_input_xfrm.py
@@ -13,7 +13,8 @@ from lib.py import rand_port
 def traffic(cfg, local_port, remote_port, ipver):
     af_inet = socket.AF_INET if ipver == "4" else socket.AF_INET6
     sock = socket.socket(af_inet, socket.SOCK_DGRAM)
-    sock.bind(("", local_port))
+    bind_addr = "127.0.0.1" if ipver == "4" else "::1"
+    sock.bind((bind_addr, local_port))
     sock.connect((cfg.remote_addr_v[ipver], remote_port))
     tgt = f"{ipver}:[{cfg.addr_v[ipver]}]:{local_port},sourceport={remote_port}"
     cmd("echo a | socat - UDP" + tgt, host=cfg.remote)


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/53](https://github.com/offsoc/linux/security/code-scanning/53)

To fix the problem, the socket should be bound to the loopback interface instead of all interfaces. This means replacing the empty string `""` in the `sock.bind` call with the appropriate loopback address for the IP version in use. For IPv4, use `"127.0.0.1"`; for IPv6, use `"::1"`. The best way to implement this is to select the correct address based on the `ipver` argument already present in the function. This change should be made only in the `traffic` function, specifically on line 16. No additional imports are required, as the code already has access to the `ipver` variable.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
