### PR TITLE
Potential fix for code scanning alert no. 63: Multiplication result converted to larger type

### DIFF
--- a/lib/sbitmap.c
+++ b/lib/sbitmap.c
@@ -219,7 +219,7 @@ static unsigned int __map_depth_with_shallow(const struct sbitmap *sb,
 	if (shallow_depth >= sb->depth)
 		return word_depth;
 
-	shallow_word_depth = word_depth * shallow_depth;
+	shallow_word_depth = (u64)word_depth * shallow_depth;
 	reminder = do_div(shallow_word_depth, sb->depth);
 
 	if (reminder >= (index + 1) * word_depth)


### PR DESCRIPTION
Potential fix for [https://github.com/offsoc/linux/security/code-scanning/63](https://github.com/offsoc/linux/security/code-scanning/63)

To fix the problem, we need to ensure that the multiplication is performed using `u64` arithmetic, not `unsigned int`. This can be done by casting one of the operands to `u64` before the multiplication. The best way is to cast `word_depth` to `u64` in the assignment to `shallow_word_depth` on line 222. Only this line needs to be changed in `lib/sbitmap.c`. No new imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
